### PR TITLE
feat: allow room members to approve join requests when no leader is selected

### DIFF
--- a/app/api/join-requests/route.ts
+++ b/app/api/join-requests/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: NextRequest) {
       .order('created_at', { ascending: false });
 
     if (roomId) {
-      // Check if user has access to this room (must be LR only)
+      // Check if user has access to this room (must be a member)
       const { data: membership, error: memberError } = await adminSupabase
         .from('mbdf_member')
         .select('role')
@@ -73,9 +73,26 @@ export async function GET(request: NextRequest) {
         .eq('user_id', user.id)
         .single() as { data: any; error: any };
 
-      if (memberError || !membership || membership.role !== 'lr') {
+      if (memberError || !membership) {
         return NextResponse.json(
-          { error: 'Access denied - LR role required', success: false },
+          { error: 'Access denied - Room membership required', success: false },
+          { status: 403 }
+        );
+      }
+
+      // Check if there's a leader in the room
+      const { data: leaderExists } = await adminSupabase
+        .from('mbdf_member')
+        .select('id')
+        .eq('room_id', roomId)
+        .eq('role', 'lr')
+        .single();
+
+      // If there's a leader, only the leader can see join requests
+      // If no leader, all members can see join requests
+      if (leaderExists && membership.role !== 'lr') {
+        return NextResponse.json(
+          { error: 'Access denied - Only the leader can view join requests when a leader exists', success: false },
           { status: 403 }
         );
       }

--- a/components/room/tabs/join-requests-tab.tsx
+++ b/components/room/tabs/join-requests-tab.tsx
@@ -53,8 +53,14 @@ export function JoinRequestsTab({ roomId, isArchived = false }: JoinRequestsTabP
     request.profiles?.company?.name?.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  // Check if current user can manage join requests (only lr)
-  const canManageRequests = currentUserRole === 'lr';
+  // Check if current user can manage join requests based on leadership status
+  const members = membersData?.items || [];
+  const hasLeader = members.some((member: any) => member.role === 'lr');
+  
+  // User can manage join requests if:
+  // 1. They are a member of the room AND
+  // 2. Either there's no leader (all members can manage) OR they are the leader
+  const canManageRequests = currentUserRole && (!hasLeader || currentUserRole === 'lr');
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -152,7 +158,7 @@ export function JoinRequestsTab({ roomId, isArchived = false }: JoinRequestsTabP
       {!canManageRequests ? (
         <div className="text-center py-8">
           <p className="text-sm text-muted-foreground">
-            Katılım taleplerini görüntülemek için LR (Lider) yetkisine sahip olmanız gerekiyor.
+            Katılım taleplerini görüntülemek için oda üyesi olmanız gerekiyor. Eğer odada bir lider varsa, sadece lider katılım taleplerini yönetebilir.
           </p>
         </div>
       ) : filteredRequests.length === 0 ? (


### PR DESCRIPTION
## Feature Description

This PR adds dynamic permission control for room members to approve join requests.

## 🔧 Changes Made

### API Level
- `app/api/join-requests/route.ts`: Added leader control
- `app/api/join-requests/[id]/route.ts`: Dynamic permission control for approve/reject operations

### UI Components
- `components/room/room-content.tsx`: Dynamic visibility for join requests tab
- `components/room/tabs/join-requests-tab.tsx`: Updated permission control

## 📋 Logic

- **If leader exists:** Only the leader can view and approve join requests
- **If no leader:** All room members can view and approve join requests

## ✅ Tested

- [x] Only leader access in rooms with leader
- [x] All members access in rooms without leader
- [x] Build successful
- [x] No TypeScript errors

## 🚀 Result

User experience improved and room management made more flexible. Members can now approve join requests when there is no leader.